### PR TITLE
graph module: library for representing graphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Rust #
 /target
 **/*.rs.bk
 Cargo.lock
+
+# IDE #
+/.idea
+*.iml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2018"
 [dependencies]
 bio = "0.28.1"
 bv = "0.10.0"
+petgraph = "0.4.13"
 rand = "0.7.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -116,24 +116,21 @@ impl GraphWaveletTree {
     /// Returns a vector containing all indices of the neighbors (successors) of the node given by
     /// index v. If v has no neighbors, an empty vector is returned.
     pub fn neighbors(&self, v: usize) -> Vec<usize> {
-        // Find the start of the adjacency list in the sequence (see access_neighbor for details)
-        let start = self.bitmap.select_1(v as u64)
-            .map(|l| l - (v-1) as u64)
-            .unwrap();
+        // Find the start and end of the adjacency list in the sequence (see access_neighbor for details)
+        let l = self.bitmap.select_1((v+1) as u64)
+            .map(|x| x - v as u64);
 
-        // Find the end of the adjacency list (i.e. usually the start of the next adjacency list).
-        // If v is the last node, the adjaceny list ends at the end of the sequence.
-        let end = self.bitmap.select_1(v as u64 +1)
-            .map(|l| l - v as u64)
+        let m = self.bitmap.select_1((v+2) as u64)
+            .map(|l| l - (v+1) as u64)
             .unwrap_or(self.sequence_length());
 
         // Compute how many neighbors v has.
-        let num_neighbors = (end - start) as usize;
+        let num_neighbors = l.map(|l| (m-l) as usize).unwrap_or(0);
 
         // Fill a vector with all indices of v's neighbors.
         let mut neighbors : Vec<usize> = Vec::with_capacity(num_neighbors);
 
-        for i in 1..num_neighbors {
+        for i in 1..num_neighbors+1 {
             neighbors.push(self.access_neighbor(v, i).unwrap());
         }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,7 +1,12 @@
 use bio::data_structures::rank_select::RankSelect;
-use bv::BitVec;
-use petgraph::graph::Graph;
+use bv::{BitVec, BitsMut};
+use petgraph::EdgeType;
+use petgraph::graph::{Graph, NodeIndices, NodeIndex, Neighbors, DefaultIx, IndexType};
 use serde::{Serialize, Deserialize};
+
+use crate::WaveletTree;
+use crate::pointerless::PointerlessWaveletTree;
+use core::borrow::BorrowMut;
 
 #[derive(Serialize, Deserialize)]
 pub struct LabelledGraphWaveletTree<T> {
@@ -11,19 +16,53 @@ pub struct LabelledGraphWaveletTree<T> {
 
 #[derive(Serialize, Deserialize)]
 pub struct GraphWaveletTree {
-    /// The wavelet tree represents the concatenated adjacency lists of the graph
-    tree: WaveletTree<usize>,
+    /// The wavelet tree represents the concatenated adjacency lists of the graph. The node indices
+    /// are stored as usize integers.
+    tree: PointerlessWaveletTree<usize>,
     /// The bitmap marks the beginnings of the adjacency lists
     bitmap: RankSelect
 }
 
 impl GraphWaveletTree {
-    pub fn from_graph(graph: Graph) -> Self {
-        unimplemented!();
+
+    pub fn from_graph<N,E,Ty:EdgeType,Ix:IndexType> (graph: Graph<N,E,Ty,Ix>) -> Self {
+        let nodes = graph.node_indices();
+
+        let mut lists = Vec::with_capacity(nodes.len());
+
+        for node in nodes {
+            lists.push(graph.neighbors(node));
+        }
+
+        Self::from_adjacency_lists(lists)
     }
 
-    pub fn from_adjacency_lists(nodes: NodeIndices, lists: Vec<Neighbours>) -> Self {
-        unimplemented!();
+    pub fn from_adjacency_lists<E,Ix:IndexType> (lists: Vec<Neighbors<E, Ix>>) -> Self {
+        // Build the sequence (which is the concatenation of the adjacency lists) and the
+        // corresponding bit vector marking the beginnings of the individual lists in the sequence.
+        let mut sequence : Vec<usize> = Vec::new();
+        let mut lists_bv : BitVec<u8> = BitVec::new();
+
+        // Iterate over all adjacency lists
+        for neighbors in lists {
+            // A '1' in the bit vector separates two adjacency lists.
+            lists_bv.push(true);
+
+            // Iterate over all neighbors (i.e. adjacent nodes that appear in the list)
+            for n in neighbors {
+                // Add the neighbor's index to the sequence
+                sequence.push(n.index());
+
+                // '0's in the bit vector represent node indices in the adjacency lists
+                lists_bv.push(false);
+            }
+        }
+
+        // Return a pointerless wavelet tree representing the sequence together with the bitmap.
+        GraphWaveletTree {
+            tree: PointerlessWaveletTree::from_slice(sequence.as_slice()),
+            bitmap: RankSelect::new(lists_bv, 1)
+        }
     }
 
     pub fn predecessor(&self, index: usize) -> NodeIndex {
@@ -47,6 +86,8 @@ mod tests {
     use super::super::*;
 
     #[test]
-
+    fn test_from_graph() {
+        unimplemented!();
+    }
 
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -193,4 +193,28 @@ mod tests {
         assert_eq!(Some(&3), gwt.tree.access(7));
     }
 
+    #[test]
+    fn test_access_neighbor() {
+        let gwt = GraphWaveletTree::from_graph(example_graph());
+
+        assert_eq!(Some(1), gwt.access_neighbor(0, 1));
+        assert_eq!(Some(3), gwt.access_neighbor(0, 2));
+        assert_eq!(None, gwt.access_neighbor(0, 3));
+
+        assert_eq!(Some(0), gwt.access_neighbor(1, 1));
+        assert_eq!(Some(3), gwt.access_neighbor(1, 2));
+        assert_eq!(Some(2), gwt.access_neighbor(1, 3));
+        assert_eq!(None, gwt.access_neighbor(1, 4));
+
+        assert_eq!(None, gwt.access_neighbor(2, 1));
+
+        assert_eq!(Some(2), gwt.access_neighbor(3, 1));
+        assert_eq!(None, gwt.access_neighbor(3, 2));
+
+        assert_eq!(Some(0), gwt.access_neighbor(4, 1));
+        assert_eq!(Some(3), gwt.access_neighbor(4, 2));
+        assert_eq!(None, gwt.access_neighbor(4, 3));
+
+    }
+
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -227,6 +227,128 @@ mod tests {
         assert_eq!(Some(3), gwt.access_neighbor(4, 2));
         assert_eq!(None, gwt.access_neighbor(4, 3));
 
+        assert_eq!(None, gwt.access_neighbor(5, 1));
+
+    }
+
+    #[test]
+    fn test_access_reverse_neighbor() {
+        let gwt = GraphWaveletTree::from_graph(example_graph());
+
+        assert_eq!(Some(1), gwt.access_reverse_neighbor(0, 1));
+        assert_eq!(Some(4), gwt.access_reverse_neighbor(0, 2));
+        assert_eq!(None, gwt.access_reverse_neighbor(0, 3));
+
+        assert_eq!(Some(0), gwt.access_reverse_neighbor(1, 1));
+        assert_eq!(None, gwt.access_reverse_neighbor(1, 2));
+
+        assert_eq!(Some(1), gwt.access_reverse_neighbor(2, 1));
+        assert_eq!(Some(3), gwt.access_reverse_neighbor(2, 2));
+        assert_eq!(None, gwt.access_reverse_neighbor(2, 3));
+
+        assert_eq!(Some(0), gwt.access_reverse_neighbor(3, 1));
+        assert_eq!(Some(1), gwt.access_reverse_neighbor(3, 2));
+        assert_eq!(Some(4), gwt.access_reverse_neighbor(3, 3));
+        assert_eq!(None, gwt.access_reverse_neighbor(3, 4));
+
+        assert_eq!(None, gwt.access_reverse_neighbor(4, 1));
+
+        assert_eq!(None, gwt.access_reverse_neighbor(5, 1));
+
+    }
+
+    #[test]
+    fn test_neighbors() {
+        let gwt = GraphWaveletTree::from_graph(example_graph());
+
+        let mut n = gwt.neighbors(0); n.sort();
+        assert_eq!(vec![1, 3], n);
+
+        let mut n = gwt.neighbors(1); n.sort();
+        assert_eq!(vec![0, 2, 3], n);
+
+        let mut n = gwt.neighbors(2); n.sort();
+        assert_eq!(Vec::<usize>::new(), n);
+
+        let mut n = gwt.neighbors(3); n.sort();
+        assert_eq!(vec![2], n);
+
+        let mut n = gwt.neighbors(4); n.sort();
+        assert_eq!(vec![0, 3], n);
+
+        let mut n = gwt.neighbors(5); n.sort();
+        assert_eq!(Vec::<usize>::new(), n);
+    }
+
+    #[test]
+    fn test_reverse_neighbors() {
+        let gwt = GraphWaveletTree::from_graph(example_graph());
+
+        let mut n = gwt.reverse_neighbors(0); n.sort();
+        assert_eq!(vec![1, 4], n);
+
+        let mut n = gwt.reverse_neighbors(1); n.sort();
+        assert_eq!(vec![0], n);
+
+        let mut n = gwt.reverse_neighbors(2); n.sort();
+        assert_eq!(vec![1, 3], n);
+
+        let mut n = gwt.reverse_neighbors(3); n.sort();
+        assert_eq!(vec![0, 1, 4], n);
+
+        let mut n = gwt.reverse_neighbors(4); n.sort();
+        assert_eq!(Vec::<usize>::new(), n);
+
+        let mut n = gwt.reverse_neighbors(5); n.sort();
+        assert_eq!(Vec::<usize>::new(), n);
+    }
+
+    #[test]
+    fn test_edge_exists() {
+        let gwt = GraphWaveletTree::from_graph(example_graph());
+
+        assert_eq!(false, gwt.edge_exists(0, 0));
+        assert_eq!(true, gwt.edge_exists(0, 1));
+        assert_eq!(false, gwt.edge_exists(0, 2));
+        assert_eq!(true, gwt.edge_exists(0, 3));
+        assert_eq!(false, gwt.edge_exists(0, 4));
+        assert_eq!(false, gwt.edge_exists(0, 5));
+
+        assert_eq!(true, gwt.edge_exists(1, 0));
+        assert_eq!(false, gwt.edge_exists(1, 1));
+        assert_eq!(true, gwt.edge_exists(1, 2));
+        assert_eq!(true, gwt.edge_exists(1, 3));
+        assert_eq!(false, gwt.edge_exists(1, 4));
+        assert_eq!(false, gwt.edge_exists(1, 5));
+
+        assert_eq!(false, gwt.edge_exists(2, 0));
+        assert_eq!(false, gwt.edge_exists(2, 1));
+        assert_eq!(false, gwt.edge_exists(2, 2));
+        assert_eq!(false, gwt.edge_exists(2, 3));
+        assert_eq!(false, gwt.edge_exists(2, 4));
+        assert_eq!(false, gwt.edge_exists(2, 5));
+
+        assert_eq!(false, gwt.edge_exists(3, 0));
+        assert_eq!(false, gwt.edge_exists(3, 1));
+        assert_eq!(true, gwt.edge_exists(3, 2));
+        assert_eq!(false, gwt.edge_exists(3, 3));
+        assert_eq!(false, gwt.edge_exists(3, 4));
+        assert_eq!(false, gwt.edge_exists(3, 5));
+
+        assert_eq!(true, gwt.edge_exists(4, 0));
+        assert_eq!(false, gwt.edge_exists(4, 1));
+        assert_eq!(false, gwt.edge_exists(4, 2));
+        assert_eq!(true, gwt.edge_exists(4, 3));
+        assert_eq!(false, gwt.edge_exists(4, 4));
+        assert_eq!(false, gwt.edge_exists(4, 5));
+
+        assert_eq!(false, gwt.edge_exists(5, 0));
+        assert_eq!(false, gwt.edge_exists(5, 1));
+        assert_eq!(false, gwt.edge_exists(5, 2));
+        assert_eq!(false, gwt.edge_exists(5, 3));
+        assert_eq!(false, gwt.edge_exists(5, 4));
+        assert_eq!(false, gwt.edge_exists(5, 5));
+
     }
 
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -143,7 +143,7 @@ impl GraphWaveletTree {
 
     /// Returns whether an edge exists between the nodes given by the indices 'from' and 'to'.
     pub fn edge_exists(&self, from: usize, to: usize) -> bool {
-        unimplemented!();
+        self.neighbors(from).contains(&to)
     }
 
     fn sequence_length(&self) -> u64 {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -90,14 +90,41 @@ impl GraphWaveletTree {
         p0.and_then(|x| self.bitmap.rank_1(x)).map(|x| x as usize)
     }
 
-    pub fn neighbors(&self, index: usize) -> Vec<usize> {
-        unimplemented!();
+    /// Returns a vector containing all indices of the neighbors (successors) of the node given by
+    /// index v. If v has no neighbors, an empty vector is returned.
+    pub fn neighbors(&self, v: usize) -> Vec<usize> {
+        // Find the start of the adjacency list in the sequence (see access_neighbor for details)
+        let start = self.bitmap.select_1(v as u64)
+            .map(|l| l - (v-1) as u64)
+            .unwrap();
+
+        // Find the end of the adjacency list (i.e. usually the start of the next adjacency list).
+        // If v is the last node, the adjaceny list ends at the end of the sequence
+        let bitmap_length = self.bitmap.bits().len();
+        let sequence_length = bitmap_length - self.bitmap.rank_1(bitmap_length-1).unwrap_or(0);
+
+        let end = self.bitmap.select_1(v as u64 +1)
+            .map(|l| l - v as u64)
+            .unwrap_or(sequence_length);
+
+        // Compute how many neighbors v has.
+        let num_neighbors = (end - start) as usize;
+
+        // Fill a vector with all indices of v's neighbors.
+        let mut neighbors : Vec<usize> = Vec::with_capacity(num_neighbors);
+
+        for i in 0..num_neighbors {
+            neighbors.push(self.access_neighbor(v, i).unwrap());
+        }
+
+        neighbors
     }
 
     pub fn reverse_neighbors(&self, index: usize) -> Vec<usize> {
         unimplemented!();
     }
 
+    /// Returns whether an edge exists between the nodes given by the indices 'from' and 'to'.
     pub fn edge_exists(&self, from: usize, to: usize) -> bool {
         unimplemented!();
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -103,13 +103,14 @@ impl GraphWaveletTree {
         // lists, which is represented by the wavelet tree.
         let p = self.tree.select(&v, i as u64);
 
-        // Then we need to find the p-th occurence of a '0' in the bitmap. This corresponds ot the
+        // Then we need to find the (p+1)-th occurence of a '0' in the bitmap. This corresponds to the
         // position of v in the bitmap representing the concatenated adjacency lists.
-        let p0 = p.and_then(|x| self.bitmap.select_0(x));
+        let p0 = p.and_then(|x| self.bitmap.select_0(x+1));
 
         // Now we can count the number of '1's up until position p0 in order to find out which
         // adjacency list the i-th occurence of v is in.
-        p0.and_then(|x| self.bitmap.rank_1(x)).map(|x| x as usize)
+        // Remember that we need to subtract 1 because we are returning an index.
+        p0.and_then(|x| self.bitmap.rank_1(x)).map(|x| (x-1) as usize)
     }
 
     /// Returns a vector containing all indices of the neighbors (successors) of the node given by

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -125,8 +125,20 @@ impl GraphWaveletTree {
         neighbors
     }
 
-    pub fn reverse_neighbors(&self, index: usize) -> Vec<usize> {
-        unimplemented!();
+    /// Returns a vector containing all indices of the reverse neighbors (predecessors) of the node given by
+    /// index v. If v has no reverse neighbors, an empty vector is returned.
+    pub fn reverse_neighbors(&self, v: usize) -> Vec<usize> {
+        // Get the number of occurences of v in the sequence. This is equal to the amount of v's reverse neighbors.
+        let num_v = self.tree.rank(&v, self.sequence_length()).unwrap_or(0) as usize;
+
+        // Fill a vector with all indices of v's reverse neighbors.
+        let mut reverse_neighbors : Vec<usize> = Vec::with_capacity(num_v);
+
+        for i in 1..num_v {
+            reverse_neighbors.push(self.access_reverse_neighbor(v, i).unwrap());
+        }
+
+        reverse_neighbors
     }
 
     /// Returns whether an edge exists between the nodes given by the indices 'from' and 'to'.

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -141,12 +141,12 @@ impl GraphWaveletTree {
     /// index v. If v has no reverse neighbors, an empty vector is returned.
     pub fn reverse_neighbors(&self, v: usize) -> Vec<usize> {
         // Get the number of occurences of v in the sequence. This is equal to the amount of v's reverse neighbors.
-        let num_v = self.tree.rank(&v, self.sequence_length()).unwrap_or(0) as usize;
+        let num_v = self.tree.rank(&v, self.sequence_length()-1).unwrap_or(0) as usize;
 
         // Fill a vector with all indices of v's reverse neighbors.
         let mut reverse_neighbors : Vec<usize> = Vec::with_capacity(num_v);
 
-        for i in 1..num_v {
+        for i in 1..num_v+1 {
             reverse_neighbors.push(self.access_reverse_neighbor(v, i).unwrap());
         }
 
@@ -295,6 +295,13 @@ mod tests {
     #[test]
     fn test_reverse_neighbors() {
         let gwt = GraphWaveletTree::from_graph(example_graph());
+
+        print!("Sequence: ");
+        for i in 0..8 {
+            print!("{:?}", gwt.tree.access(i).unwrap());
+        }
+        println!("\nTree: {:?}", gwt.tree);
+
 
         let mut n = gwt.reverse_neighbors(0); n.sort();
         assert_eq!(vec![1, 4], n);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,18 +1,10 @@
 use bio::data_structures::rank_select::RankSelect;
-use bv::{BitVec, BitsMut};
+use bv::BitVec;
 use petgraph::EdgeType;
-use petgraph::graph::{Graph, NodeIndices, NodeIndex, Neighbors, DefaultIx, IndexType};
+use petgraph::graph::{Graph, Neighbors, IndexType};
 use serde::{Serialize, Deserialize};
-
 use crate::WaveletTree;
 use crate::pointerless::PointerlessWaveletTree;
-use core::borrow::BorrowMut;
-
-#[derive(Serialize, Deserialize)]
-pub struct LabelledGraphWaveletTree<T> {
-    graphTree: GraphWaveletTree,
-    labels: Vec<T>
-}
 
 #[derive(Serialize, Deserialize)]
 pub struct GraphWaveletTree {
@@ -95,18 +87,18 @@ impl GraphWaveletTree {
 
         // Now we can count the number of '1's up until position p0 in order to find out which
         // adjacency list the i-th occurence of v is in.
-        p0.map(|x| self.bitmap.rank_1(x) as usize)
+        p0.and_then(|x| self.bitmap.rank_1(x)).map(|x| x as usize)
     }
 
-    pub fn predecessor(&self, index: usize) -> NodeIndex {
+    pub fn neighbors(&self, index: usize) -> Vec<usize> {
         unimplemented!();
     }
 
-    pub fn successor(&self, index: usize) -> NodeIndex {
+    pub fn reverse_neighbors(&self, index: usize) -> Vec<usize> {
         unimplemented!();
     }
 
-    pub fn edge_exists(&self, predecessorIndex: usize, successorIndex: usize) -> bool {
+    pub fn edge_exists(&self, from: usize, to: usize) -> bool {
         unimplemented!();
     }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -83,6 +83,21 @@ impl GraphWaveletTree {
         n.and_then(|x| self.tree.access(x)).map(|x| x.clone())
     }
 
+    /// Access the i-th reverse neighbor (i.e. predecessor) of node v
+    pub fn access_reverse_neighbor(&self, v: usize, i: usize) -> Option<usize> {
+        // First we need to find the i-th occurrence of v in the sequence of concatenated adjacency
+        // lists, which is represented by the wavelet tree.
+        let p = self.tree.select(&v, i as u64);
+
+        // Then we need to find the p-th occurence of a '0' in the bitmap. This corresponds ot the
+        // position of v in the bitmap representing the concatenated adjacency lists.
+        let p0 = p.and_then(|x| self.bitmap.select_0(x));
+
+        // Now we can count the number of '1's up until position p0 in order to find out which
+        // adjacency list the i-th occurence of v is in.
+        p0.map(|x| self.bitmap.rank_1(x) as usize)
+    }
+
     pub fn predecessor(&self, index: usize) -> NodeIndex {
         unimplemented!();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod pointers;
 pub mod pointerless;
+pub mod graph;
 
 pub trait WaveletTree<T> {
     fn from_slice(sequence: &[T]) -> Self;


### PR DESCRIPTION
The graph module can now be used to represent graphs from the petgraph package using pointerless wavelet trees. Resolves #10 